### PR TITLE
fix: force unfurl

### DIFF
--- a/controllers/meetup.js
+++ b/controllers/meetup.js
@@ -17,7 +17,9 @@ const sendCommandsToSlack = (res, commands) => {
   res.status(200).json(
     {text: `
     List of possible commands:
-    ${slackText}`}
+    ${slackText}`,
+    response_type: 'in_channel',
+  }
   )
 }
 

--- a/controllers/meetup.js
+++ b/controllers/meetup.js
@@ -5,6 +5,8 @@ const sendMeetupInfoToSlack = (res,data) => {
   res.status(200).json(
     {text: `${data.nextMeetupLink}`, 
     response_type: 'in_channel',
+    unfurl_links: true,
+    unfurl_media: true,
     attachments:[{text: `*${data.message}*`}]
   })
 }


### PR DESCRIPTION
this will always unfurl images and links that are scraped by the slack api.  Note if the link has been recently posted, slack will still not unfurl.